### PR TITLE
Fix native proxy adapter for tns > 6.2

### DIFF
--- a/runtime/svelte-native/proxy-adapter-native.js
+++ b/runtime/svelte-native/proxy-adapter-native.js
@@ -1,6 +1,6 @@
 /* global document */
 
-import { NavigationType } from 'tns-core-modules/ui/frame/frame-common'
+import { NavigationType } from 'tns-core-modules/ui/frame'
 
 import ProxyAdapterDom from '../proxy-adapter-dom'
 


### PR DESCRIPTION
the modules were rearranged in tns-core-modules 6.2, Fallbacks were added for the modules, but here we were accessing  the file directly, this reverts it to referencing the module.
This allows the use of HMR in svelte-native again