### PR TITLE
Check for false fragment

### DIFF
--- a/runtime/svelte-hooks.js
+++ b/runtime/svelte-hooks.js
@@ -175,7 +175,7 @@ export const createProxiedComponent = (
     //
     // 			And also, to support keyed list, it needs to be called each time the
     // 			component is moved (same as $$.fragment.m)
-    if (onMount) {
+    if (onMount && targetCmp.$$.fragment) {
       const m = targetCmp.$$.fragment.m
       targetCmp.$$.fragment.m = (...args) => {
         const result = m(...args)


### PR DESCRIPTION
If svelte is ran with dev mode off `component.$$.fragment` is `false`. This causes hmr to crash do to attempting to access `component.$$.fragment.m`. The fix is simple enough, just check for `false` before accessing.

This fixes #9.