### PR TITLE
fix: update proxy to include 4379set that was added in svelte 3.24.1 (fix #17)

### DIFF
--- a/runtime/proxy.js
+++ b/runtime/proxy.js
@@ -7,7 +7,7 @@
 import { createProxiedComponent } from './svelte-hooks.js'
 
 const handledMethods = ['constructor', '$destroy']
-const forwardedMethods = ['$set', '$on']
+const forwardedMethods = ['$set', '$$set', '$on']
 
 const logError = (msg, err) => {
   // eslint-disable-next-line no-console


### PR DESCRIPTION
This is as unstable as before, any additions or ommisions in future svelte versions are going to break again. Maybe proxy everything exept a blacklist?