### PR TITLE
fix: handle paths with dollar signs

### DIFF
--- a/lib/make-hot.js
+++ b/lib/make-hot.js
@@ -429,7 +429,9 @@ const createMakeHot = ({ walk, meta = 'import.meta', hotApi, adapter }) => {
       acceptable: isAcceptable(hotOptions, compileOptions, compiled),
     })
 
-    return compiledCode.replace(/(\n?export default ([^;]*);)/, replacement)
+    return compiledCode.replace(/(\n?export default ([^;]*);)/, (match, $1, $2) => {
+      return replacement.replace(/\$2/g, () => $2)
+    })
   }
 
   // rollup-plugin-svelte-hot needs hotApi path (for tests)


### PR DESCRIPTION
**What's the problem this PR addresses?**

If the filepath contains two dollar signs (`$$`) then the replacement here https://github.com/rixo/svelte-hmr/blob/f99471890cd4c2c59ba95a3e0581e93a2023fbeb/lib/make-hot.js#L432 removes one of them causing webpack to look for a path that doesn't exist

`.yarn/$$virtual/svelte-hmr-virtual-ffb4749d44/2/svelte-hmr` turns into `.yarn/$virtual/svelte-hmr-virtual-ffb4749d44/2/svelte-hmr`

**How did you fix it?**

Use the callback version of replace which uses the literal value provided