### PR TITLE
fix hmr + ssr: disable hydration when re-rendering a proxied component

### DIFF
--- a/runtime/svelte-hooks.js
+++ b/runtime/svelte-hooks.js
@@ -124,7 +124,12 @@ export const createProxiedComponent = (
     } else {
       delete props.$$inject
     }
-    options = Object.assign({}, initialOptions, { target, anchor, props })
+    options = Object.assign({}, initialOptions, {
+      target,
+      anchor,
+      props,
+      hydrate: false,
+    })
   }
 
   const instrument = targetCmp => {


### PR DESCRIPTION
Hi all, great work!  Loving my dev experience with svelte-hmr + snowpack.

I'm building a Svelte app with Snowpack 3 that supports SSR and HMR in development, and noticed a bug when hydrating a component.

The problem: When a component is initialized with `hydrate: true`, it detaches all of it's children from the DOM.
https://github.com/sveltejs/svelte/blob/eeeeb4998689df9cd61a3c0f279eb8e312d99304/src/runtime/internal/Component.ts#L147-L151

Why this is a problem: This additional initialization step breaks HMR because the comment node that it uses as a DOM anchor is removed along with everything else.

My solution: Simply toggle `hydrate` for the replacement component.  We've already hydrated the SSR'd HTML anyway, so there's no need to run hydration logic it for hot updates.  This circumvents the problem outlined above.