### PR TITLE
Native Adapter Fixes

### DIFF
--- a/runtime/svelte-native/patch-page-show-modal.js
+++ b/runtime/svelte-native/patch-page-show-modal.js
@@ -18,7 +18,7 @@
 
 // FIXME should we override ViewBase#showModal instead?
 // eslint-disable-next-line import/no-unresolved
-import { Page } from 'tns-core-modules/ui/page'
+import { Page } from '@nativescript/core'
 
 const prop =
   typeof Symbol !== 'undefined'

--- a/runtime/svelte-native/proxy-adapter-native.js
+++ b/runtime/svelte-native/proxy-adapter-native.js
@@ -1,8 +1,5 @@
 /* global document */
 
-// eslint-disable-next-line import/no-unresolved
-import { NavigationType } from 'tns-core-modules/ui/frame'
-
 import { adapter as ProxyAdapterDom } from '../proxy-adapter-dom'
 
 import { patchShowModal, getModalData } from './patch-page-show-modal'
@@ -94,13 +91,13 @@ const replacePage = (frame, newPageElement) => {
   const navigationContext = {
     entry: newBackstackEntry,
     isBackNavigation: false,
-    navigationType: NavigationType.replace,
+    navigationType: 2 /* NavigationType replace */,
   }
   frame._navigationQueue.push(navigationContext)
   frame._processNextNavigationEntry()
 }
 
-export default class ProxyAdapterNative extends ProxyAdapterDom {
+export const adapter = class ProxyAdapterNative extends ProxyAdapterDom {
   constructor(instance) {
     super(instance)
 


### PR DESCRIPTION
Switch to `@nativescript/core` imports for NS6+ compat
export `adapter` to match import