### PR TITLE
Fixes #2

### DIFF
--- a/runtime/proxy.js
+++ b/runtime/proxy.js
@@ -109,7 +109,7 @@ const copyComponentProperties = (proxy, cmp, previous) => {
           // order to most closely follow non-hmr behaviour.
           cmp[prop] = value
           // who knows? maybe the value has been transformed somehow
-          proxy[prop] = cmp[prop]
+          //proxy[prop] = cmp[prop]
         },
       })
       return true

--- a/runtime/proxy.js
+++ b/runtime/proxy.js
@@ -108,8 +108,6 @@ const copyComponentProperties = (proxy, cmp, previous) => {
           // gives... if it throws an error, we want to throw the same error in
           // order to most closely follow non-hmr behaviour.
           cmp[prop] = value
-          // who knows? maybe the value has been transformed somehow
-          //proxy[prop] = cmp[prop]
         },
       })
       return true


### PR DESCRIPTION
Fixes "Maximum call stack size" errors when using accessors / prevents infinite loop.
The comment above the line causing the infinite loop ...
https://github.com/rixo/svelte-hmr/blob/00c4d8d94f167dec3edaf9cf1a44cee7021e889b/runtime/proxy.js#L111-L112
... implies it was added "just in case if ... _something_", so I think it should be pretty safe to comment/remove it (?) 🤔