### PR TITLE
fix acceptNamedExports option in tools that statically analyse accet() like Vite

### DIFF
--- a/packages/svelte-hmr/lib/make-hot.js
+++ b/packages/svelte-hmr/lib/make-hot.js
@@ -80,7 +80,7 @@ const renderApplyHmr = ({
   //
   `${imports.join(';')};${`
     if (${meta} && ${meta}.hot) {
-      if (false) ${meta}.hot.accept();
+      ${acceptable ? `if (false) ${meta}.hot.accept();` : ''};
       $2 = ${globalName}.applyHmr({
         m: ${meta},
         id: ${json(id)},


### PR DESCRIPTION
The option is meant to not accept components with named exports from context=module. It is not documented but it can help some people in some situation, so it's better to have it working, if possible.

Currently it doesn't work with tools that do static analysis of the `hot.accept` string, because currently the string always appears in component's HMR transformed code, even if `accept()` is not really called eventually. 

This modification fixes it.