### PR TITLE
replace deprecated String.prototype.substr()

### DIFF
--- a/packages/svelte-hmr/runtime/proxy.js
+++ b/packages/svelte-hmr/runtime/proxy.js
@@ -49,7 +49,7 @@ const relayCalls = (getTarget, names, dest = {}) => {
   return dest
 }
 
-const isInternal = key => key !== '$$' && key.substr(0, 2) === '$$'
+const isInternal = key => key !== '$$' && key.slice(0, 2) === '$$'
 
 // This is intented as a somewhat generic / prospective fix to the situation
 // that arised with the introduction of $$set in Svelte 3.24.1 -- trying to


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.