### PR TITLE
fix: set default value for option.optimistic to false 

### DIFF
--- a/.changeset/spotty-garlics-exist.md
+++ b/.changeset/spotty-garlics-exist.md
@@ -1,0 +1,5 @@
+---
+'svelte-hmr': patch
+---
+
+change options.optimistic default value from true to false to fix buggy behavior on fatal runtime errors

--- a/packages/svelte-hmr/lib/make-hot.js
+++ b/packages/svelte-hmr/lib/make-hot.js
@@ -18,7 +18,8 @@ const defaultHotOptions = {
   // don't reload on fatal error
   noReload: false,
   // try to recover after runtime errors during component init
-  optimistic: true,
+  // defaults to false because some runtime errors are fatal and require a full reload
+  optimistic: false,
   // auto accept modules of components that have named exports (i.e. exports
   // from context="module")
   acceptNamedExports: true,


### PR DESCRIPTION
to prevent fatal runtime errors from breaking the page

see https://github.com/sveltejs/kit/pull/5108