### PR TITLE
fix: support new 'external' value for compileOptions.css introduced in svelte 3.53.0

### DIFF
--- a/.changeset/few-cycles-cry.md
+++ b/.changeset/few-cycles-cry.md
@@ -1,0 +1,5 @@
+---
+'svelte-hmr': patch
+---
+
+support 'external' as value for compileOptions.css

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "pnpm": {
     "overrides": {
+      "minimatch@^3.0.4": "^3.1.2",
       "svelte-hmr": "workspace:*"
     },
     "peerDependencyRules": {

--- a/packages/svelte-hmr/lib/make-hot.js
+++ b/packages/svelte-hmr/lib/make-hot.js
@@ -444,7 +444,7 @@ const createMakeHot = ({ resolveAbsoluteImport, pkg = {} }) => ({
 
     const { importAdapterName, injectCss } = hotOptions
 
-    const emitCss = compileOptions && compileOptions.css === false
+    const emitCss = compileOptions && (compileOptions.css === false || compileOptions.css === 'external')
 
     const preserveLocalState = resolvePreserveLocalState({
       hotOptions,

--- a/packages/svelte-hmr/lib/make-hot.js
+++ b/packages/svelte-hmr/lib/make-hot.js
@@ -444,7 +444,9 @@ const createMakeHot = ({ resolveAbsoluteImport, pkg = {} }) => ({
 
     const { importAdapterName, injectCss } = hotOptions
 
-    const emitCss = compileOptions && (compileOptions.css === false || compileOptions.css === 'external')
+    const emitCss =
+      compileOptions &&
+      (compileOptions.css === false || compileOptions.css === 'external')
 
     const preserveLocalState = resolvePreserveLocalState({
       hotOptions,

--- a/playground/kit-app/package.json
+++ b/playground/kit-app/package.json
@@ -7,8 +7,8 @@
 		"@fontsource/fira-mono": "^4.5.0"
 	},
 	"devDependencies": {
-		"@sveltejs/adapter-auto": "next",
-		"@sveltejs/kit": "next",
+		"@sveltejs/adapter-auto": "^1.0.0-next.75",
+		"@sveltejs/kit": "^1.0.0-next.483",
 		"@types/cookie": "^0.5.1",
 		"svelte": "^3.50.1",
 		"svelte-check": "^2.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 lockfileVersion: 5.4
 
 overrides:
+  minimatch@^3.0.4: ^3.1.2
   svelte-hmr: workspace:*
 
 importers:
@@ -55,8 +56,8 @@ importers:
   playground/kit-app:
     specifiers:
       '@fontsource/fira-mono': ^4.5.0
-      '@sveltejs/adapter-auto': next
-      '@sveltejs/kit': next
+      '@sveltejs/adapter-auto': ^1.0.0-next.75
+      '@sveltejs/kit': ^1.0.0-next.483
       '@types/cookie': ^0.5.1
       svelte: ^3.50.1
       svelte-check: ^2.7.1
@@ -2289,7 +2290,7 @@ packages:
       eslint-import-resolver-node: 0.3.4
       eslint-module-utils: 2.6.0_stdpjldesrblg4m7sdww5hkinq
       has: 1.0.3
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       object.values: 1.1.3
       read-pkg-up: 2.0.0
       resolve: 1.20.0
@@ -2367,7 +2368,7 @@ packages:
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.3.0
       lodash: 4.17.21
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       mkdirp: 0.5.5
       natural-compare: 1.4.0
       optionator: 0.8.3
@@ -2846,7 +2847,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: false
@@ -2857,7 +2858,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -3683,8 +3684,8 @@ packages:
     resolution: {integrity: sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=}
     dev: false
 
-  /minimatch/3.0.4:
-    resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
+  /minimatch/3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
 
@@ -3756,7 +3757,7 @@ packages:
       he: 1.2.0
       js-yaml: 3.13.1
       log-symbols: 2.2.0
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       mkdirp: 0.5.4
       ms: 2.1.1
       node-environment-flags: 1.0.5
@@ -3802,7 +3803,7 @@ packages:
       array-differ: 1.0.0
       array-union: 1.0.2
       arrify: 1.0.1
-      minimatch: 3.0.4
+      minimatch: 3.1.2
     dev: true
 
   /mute-stream/0.0.8:
@@ -4815,7 +4816,7 @@ packages:
     resolution: {integrity: sha512-3lVqBir7WuKDHGrKRDn/1Ye3kwpXaDOMsiRP1wd6wpZW56gJhsbp5RqQpA6JG/P+pkXizygnr1dKR8vzWaVsfA==}
     dependencies:
       es6-promise: 3.3.1
-      graceful-fs: 4.2.9
+      graceful-fs: 4.2.10
       mkdirp: 0.5.5
       rimraf: 2.7.1
     dev: true


### PR DESCRIPTION
fixes #62 