### PR TITLE
Make sure to display the error message on overlay

### DIFF
--- a/packages/svelte-hmr/runtime/overlay.js
+++ b/packages/svelte-hmr/runtime/overlay.js
@@ -103,7 +103,16 @@ const ErrorOverlay = () => {
   }
 
   const addError = (error, title) => {
-    const message = (error && error.stack) || error
+    let message
+    if (error && error.stack) {
+      if (error.message && error.stack.includes(error.message)) {
+        message = error.stack
+      } else {
+        message = error.message + '\n' + error.stack
+      }
+    } else {
+      message = error
+    }
     errors.push({ title, message })
     update()
   }


### PR DESCRIPTION
as some errors might be passed to `addError` with a `stack` attribute not including the error `message`