### PR TITLE
Closes #68: Exposes ProxyComponent reload function in internal API.

### DIFF
--- a/packages/svelte-hmr/runtime/proxy.js
+++ b/packages/svelte-hmr/runtime/proxy.js
@@ -363,6 +363,9 @@ export function createProxy({
             },
             options
           )
+
+          // Assign reload function to internal API.
+          this.$$.hmr_reload = reload
         } catch (err) {
           // If we fail to create a proxy instance, any instance, that means
           // that we won't be able to fix this instance when it is updated.

--- a/packages/svelte-hmr/runtime/svelte-hooks.js
+++ b/packages/svelte-hmr/runtime/svelte-hooks.js
@@ -269,6 +269,11 @@ export const createProxiedComponent = (
         cmp = createComponent(Component, restore, cmp)
       }
 
+      if (previous) {
+        // previous can be null if last constructor has crashed
+        cmp.$$.hmr_reload = previous.$$.hmr_reload
+      }
+
       cmp.$$.hmr_cmp = cmp
 
       for (const fn of afterCallbacks) {


### PR DESCRIPTION
This PR exposes the `reload` mechanism of ProxyComponent at `component.$$.hmr_reload`. This allows bespoke or custom reloading of components beyond just the `import.meta.hot` / HMR support. It can be useful depending on the deployment platform for a give Svelte app to be able to reload components based on other conditions beyond purely HMR use cases. As mentioned in #68 I develop a UI framework that is deployed on the FoundryVTT platform that has its own "hot reload" hooks / events that are fired when configuration changes. In particular this is useful for i18n / localization configuration changes. This PR allows me to connect the deployment platform hot reload functionality to reload a Svelte component on these changes. This can be broadly useful for any other use cases as well. 

It would be great to review this use case in particular when it comes to formally merging in `svelte-hmr` to the mainline Svelte releases v4 / v5, etc. 