### PR TITLE
support Svelte 4

### DIFF
--- a/packages/svelte-hmr/package.json
+++ b/packages/svelte-hmr/package.json
@@ -23,7 +23,7 @@
     "node": "^12.20 || ^14.13.1 || >= 16"
   },
   "peerDependencies": {
-    "svelte": ">=3.19.0"
+    "svelte": "^3.19.0 || ^4.0.0-next.0"
   },
   "devDependencies": {
     "dotenv": "^10.0.0",


### PR DESCRIPTION
```
$ npm init
$ npm install @sveltejs/vite-plugin-svelte@latest
$ npm install --loglevel svelte
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: svelte-hmr@0.15.1
npm WARN Found: svelte@4.0.0-next.0
npm WARN node_modules/svelte
npm WARN   svelte@"^4.0.0-next.0" from the root project
npm WARN   2 more (@sveltejs/vite-plugin-svelte, @sveltejs/vite-plugin-svelte-inspector)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer svelte@">=3.19.0" from svelte-hmr@0.15.1
npm WARN node_modules/@sveltejs/vite-plugin-svelte/node_modules/svelte-hmr
npm WARN   svelte-hmr@"^0.15.1" from @sveltejs/vite-plugin-svelte@2.4.1
npm WARN   node_modules/@sveltejs/vite-plugin-svelte
npm WARN 
npm WARN Conflicting peer dependency: svelte@3.59.1
npm WARN node_modules/svelte
npm WARN   peer svelte@">=3.19.0" from svelte-hmr@0.15.1
npm WARN   node_modules/@sveltejs/vite-plugin-svelte/node_modules/svelte-hmr
npm WARN     svelte-hmr@"^0.15.1" from @sveltejs/vite-plugin-svelte@2.4.1
npm WARN     node_modules/@sveltejs/vite-plugin-svelte
```