### PR TITLE
fix: escape paths in injected imports

### DIFF
--- a/.changeset/tiny-tomatoes-switch.md
+++ b/.changeset/tiny-tomatoes-switch.md
@@ -1,0 +1,5 @@
+---
+'svelte-hmr': patch
+---
+
+Fix injecting imports whose paths contain special characters

--- a/packages/svelte-hmr/lib/make-hot.js
+++ b/packages/svelte-hmr/lib/make-hot.js
@@ -75,8 +75,8 @@ const renderApplyHmr = ({
   preserveLocalState,
   emitCss,
   imports = [
-    `import * as ${globalName} from '${hotApiImport}'`,
-    `import { adapter as ${importAdapterName} } from '${adapterImport}'`,
+    `import * as ${globalName} from ${JSON.stringify(hotApiImport)}`,
+    `import { adapter as ${importAdapterName} } from ${JSON.stringify(adapterImport)}`,
   ],
 }) =>
   // this silly formatting keeps all original characters in their position,


### PR DESCRIPTION
Fixes #77. We can't just wrap the `hotApiImport` and `adapterImport` paths in single quotes, because any single quotes inside of them will result in invalid code being generated. I'm instead running them through `JSON.stringify`.

I'm unable to get the tests to run locally, so I haven't run the tests and I don't know whether this breaks anything. I haven't tried running them with older versions of Node, but it also looks like CI has been red on master for a while.

This repo is also on an old version of pnpm that does not work in Node 20.