### PR TITLE
Update proxy.js

### DIFF
--- a/packages/svelte-hmr/runtime/proxy.js
+++ b/packages/svelte-hmr/runtime/proxy.js
@@ -379,7 +379,7 @@ export function createProxy({
             fatalError = true
             logError(
               `Unrecoverable HMR error in ${debugName}: ` +
-                `next update will trigger a full reload`
+                `next update will trigger a full reload`, err
             )
           }
           throw err


### PR DESCRIPTION
In [Astro](https://github.com/withastro/astro), when there is an error in our code, the page crash and it just display

```txt
[HMR][Svelte] Unrecoverable HMR error in <Component>: next update will trigger a full reload
```

as error. I think we should also log the error