### PR TITLE
support Svelte 5

### DIFF
--- a/.changeset/pretty-zoos-add.md
+++ b/.changeset/pretty-zoos-add.md
@@ -1,0 +1,5 @@
+---
+'svelte-hmr': patch
+---
+
+Accept Svelte 5 as peer dependency

--- a/packages/svelte-hmr/package.json
+++ b/packages/svelte-hmr/package.json
@@ -23,7 +23,7 @@
     "node": "^12.20 || ^14.13.1 || >= 16"
   },
   "peerDependencies": {
-    "svelte": "^3.19.0 || ^4.0.0"
+    "svelte": "^3.19.0 || ^4.0.0 || ^5.0.0-next.0"
   },
   "devDependencies": {
     "dotenv": "^10.0.0",


### PR DESCRIPTION
Expand the peer dependency range for Svelte to include Svelte 5 prereleases.

SvelteKit uses `svelte-hmr` under the hood, but given that `svelte-hmr` doesn't allow Svelte 5, strict package managers will consider a SvelteKit + Svelte 5 project invalid even if SvelteKit supports it in the dependency range.

Here's what `yarn explain peer-requirements` has to say on the matter:

```
We have a problem with svelte, which is provided with version 5.0.0-next.17.
It is needed by the following direct dependencies of workspaces in your project:

  ✓ @storybook/sveltekit@portal:/Users/jeppe/dev/work/storybook/storybook/code/frameworks/sveltekit::locator=svelte-kit-prerelease-ts%40workspace%3A. [f85c6] (via ^4.0.0 || ^5.0.0-next.16)

However, those packages themselves have more dependencies listing svelte as peer dependency:

  ✓ @sveltejs/vite-plugin-svelte-inspector@npm:2.0.0 [c7b72] (via ^4.0.0 || ^5.0.0-next.0)
  ✘ svelte-hmr@npm:0.15.3 [c7b72] (via ^3.19.0 || ^4.0.0)
  ✓ @sveltejs/vite-plugin-svelte@npm:3.0.1 [cedf8] (via ^4.0.0 || ^5.0.0-next.0)
  ✓ svelte-preprocess@npm:5.1.1 [cedf8] (via ^3.23.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0)
  ✓ @storybook/svelte-vite@portal:/Users/jeppe/dev/work/storybook/storybook/code/frameworks/svelte-vite::locator=svelte-kit-prerelease-ts%40workspace%3A. [f0054] (via ^4.0.0 || ^5.0.0-next.16)

Put together, the final range we computed is ^4.0.0 || ^4.0.0
```

This is currently blocking Storybook from testing against Svelte 5 in our ecosystem CI